### PR TITLE
Fix exercise language format in GitHub importer

### DIFF
--- a/lib/mumukit/sync/store/github/guide_reader.rb
+++ b/lib/mumukit/sync/store/github/guide_reader.rb
@@ -61,6 +61,7 @@ class Mumukit::Sync::Store::Github
         builder = ExerciseBuilder.new
 
         meta = read_yaml_file(File.join(root, 'meta.yml'))
+        meta['language'] &&= { name: meta['language'] }
 
         builder.meta = meta
         builder.id = id

--- a/spec/data/simple-guide/8_sample_with_language/description.md
+++ b/spec/data/simple-guide/8_sample_with_language/description.md
@@ -1,0 +1,1 @@
+##Sample Description

--- a/spec/data/simple-guide/8_sample_with_language/meta.yml
+++ b/spec/data/simple-guide/8_sample_with_language/meta.yml
@@ -1,0 +1,7 @@
+tags:
+  - foo
+  - bar
+  - baz
+locale: en
+layout: input_bottom
+language: sqlite

--- a/spec/data/simple-guide/8_sample_with_language/test.hs
+++ b/spec/data/simple-guide/8_sample_with_language/test.hs
@@ -1,0 +1,1 @@
+pending

--- a/spec/mumukit/guide_reader_spec.rb
+++ b/spec/mumukit/guide_reader_spec.rb
@@ -112,6 +112,7 @@ describe Mumukit::Sync::Store::Github::GuideReader do
         expect { reader.read_guide! }.to raise_error('Missing meta.yml')
       end
     end
+
     context 'when guide has full data' do
       let(:reader) { Mumukit::Sync::Store::Github::GuideReader.new('spec/data/full-guide', repo) }
       let!(:guide) { reader.read_guide! }

--- a/spec/mumukit/guide_reader_spec.rb
+++ b/spec/mumukit/guide_reader_spec.rb
@@ -19,7 +19,7 @@ describe Mumukit::Sync::Store::Github::GuideReader do
       let(:guide) { reader.read_guide! }
 
       it { expect(guide[:slug]).to eq 'mumuki/functional-haskell-guide-1'}
-      it { expect(guide[:exercises].count).to eq 6 }
+      it { expect(guide[:exercises].count).to eq 7 }
       it { expect(guide[:description]).to eq "Awesome guide\n" }
       it { expect(guide[:language][:name]).to eq 'haskell' }
       it { expect(guide[:locale]).to eq 'en' }
@@ -42,6 +42,13 @@ describe Mumukit::Sync::Store::Github::GuideReader do
         it { expect(subject[:expectations].size).to eq 2 }
         it { expect(subject[:tag_list]).to include *%w(foo bar baz) }
         it { expect(subject[:layout]).to be nil }
+        it { expect(subject[:language]).to be nil }
+      end
+
+      context 'when importing exercise with language override' do
+        subject { find_exercise_by_id(guide, 8) }
+
+        it { expect(subject[:language][:name]).to eq 'sqlite' }
       end
 
       context 'when importing exercise with errors' do

--- a/spec/mumukit/guide_reader_spec.rb
+++ b/spec/mumukit/guide_reader_spec.rb
@@ -26,77 +26,75 @@ describe Mumukit::Sync::Store::Github::GuideReader do
       it { expect(guide[:teacher_info]).to eq 'information' }
 
       context 'when importing basic exercise' do
-        let(:imported_exercise) { find_exercise_by_id(guide, 1) }
+        subject { find_exercise_by_id(guide, 1) }
 
-        it { expect(imported_exercise).to_not be nil }
-        it { expect(imported_exercise[:default_content]).to_not be nil }
-        it { expect(imported_exercise[:author]).to eq guide[:author] }
-        it { expect(imported_exercise[:name]).to eq 'sample_title' }
-        it { expect(imported_exercise[:extra_visible]).to be true }
-        it { expect(imported_exercise[:description]).to eq '##Sample Description' }
-        it { expect(imported_exercise[:test]).to eq 'pending' }
-        it { expect(imported_exercise[:extra]).to eq "extra\n" }
-        it { expect(imported_exercise[:hint]).to be nil }
-        it { expect(imported_exercise[:teacher_info]).to eq 'information' }
-        it { expect(imported_exercise[:corollary]).to be nil }
-        it { expect(imported_exercise[:expectations].size).to eq 2 }
-        it { expect(imported_exercise[:tag_list]).to include *%w(foo bar baz) }
-        it { expect(guide[:description]).to eq "Awesome guide\n" }
-        it { expect(imported_exercise[:layout]).to be nil }
-
+        it { expect(subject).to_not be nil }
+        it { expect(subject[:default_content]).to_not be nil }
+        it { expect(subject[:author]).to eq guide[:author] }
+        it { expect(subject[:name]).to eq 'sample_title' }
+        it { expect(subject[:extra_visible]).to be true }
+        it { expect(subject[:description]).to eq '##Sample Description' }
+        it { expect(subject[:test]).to eq 'pending' }
+        it { expect(subject[:extra]).to eq "extra\n" }
+        it { expect(subject[:hint]).to be nil }
+        it { expect(subject[:teacher_info]).to eq 'information' }
+        it { expect(subject[:corollary]).to be nil }
+        it { expect(subject[:expectations].size).to eq 2 }
+        it { expect(subject[:tag_list]).to include *%w(foo bar baz) }
+        it { expect(subject[:layout]).to be nil }
       end
 
       context 'when importing exercise with errors' do
-        let(:imported_exercise) { find_exercise_by_id(guide, 2) }
+        subject { find_exercise_by_id(guide, 2) }
 
-        it { expect(imported_exercise).to be nil }
+        it { expect(subject).to be nil }
       end
 
       context 'when importing exercise with hint and corollary' do
-        let(:imported_exercise) { find_exercise_by_id(guide, 3) }
+        subject { find_exercise_by_id(guide, 3) }
 
-        it { expect(imported_exercise).to_not be nil }
-        it { expect(imported_exercise[:name]).to eq "custom_name" }
-        it { expect(imported_exercise[:hint]).to eq "Try this: blah blah\n" }
-        it { expect(imported_exercise[:corollary]).to eq "And the corollary is...\n" }
+        it { expect(subject).to_not be nil }
+        it { expect(subject[:name]).to eq "custom_name" }
+        it { expect(subject[:hint]).to eq "Try this: blah blah\n" }
+        it { expect(subject[:corollary]).to eq "And the corollary is...\n" }
       end
 
       context 'when importing with layout' do
-        let(:imported_exercise) { find_exercise_by_id(guide, 4) }
+        subject { find_exercise_by_id(guide, 4) }
 
-        it { expect(imported_exercise).to_not be nil }
-        it { expect(imported_exercise[:layout]).to eq 'input_bottom' }
+        it { expect(subject).to_not be nil }
+        it { expect(subject[:layout]).to eq 'input_bottom' }
       end
 
       context 'when importing playground' do
-        let(:imported_exercise) { find_exercise_by_id(guide, 5) }
+        subject { find_exercise_by_id(guide, 5) }
 
-        it { expect(imported_exercise).to_not be nil }
-        it { expect(imported_exercise[:name]).to eq 'playground' }
-        it { expect(imported_exercise[:type]).to eq 'playground' }
+        it { expect(subject).to_not be nil }
+        it { expect(subject[:name]).to eq 'playground' }
+        it { expect(subject[:type]).to eq 'playground' }
 
       end
 
       context 'when importing reading' do
-        let(:imported_exercise) { find_exercise_by_id(guide, 6) }
+        subject { find_exercise_by_id(guide, 6) }
 
-        it { expect(imported_exercise).to_not be nil }
-        it { expect(imported_exercise[:name]).to eq 'reading' }
-        it { expect(imported_exercise[:type]).to eq 'reading' }
-        it { expect(imported_exercise[:test]).to be_blank}
-        it { expect(imported_exercise[:expectations]).to be_blank }
-        it { expect(imported_exercise[:hint]).to be_blank }
-        it { expect(imported_exercise[:corollary]).to be_blank }
-        it { expect(imported_exercise[:extra]).to be_blank }
-        it { expect(imported_exercise[:description]).to eq "Now read the following text\n"}
+        it { expect(subject).to_not be nil }
+        it { expect(subject[:name]).to eq 'reading' }
+        it { expect(subject[:type]).to eq 'reading' }
+        it { expect(subject[:test]).to be_blank}
+        it { expect(subject[:expectations]).to be_blank }
+        it { expect(subject[:hint]).to be_blank }
+        it { expect(subject[:corollary]).to be_blank }
+        it { expect(subject[:extra]).to be_blank }
+        it { expect(subject[:description]).to eq "Now read the following text\n"}
 
       end
 
       context 'when importing free_form' do
-        let(:imported_exercise) { find_exercise_by_id(guide, 7) }
+        subject { find_exercise_by_id(guide, 7) }
 
-        it { expect(imported_exercise).to_not be nil }
-        it { expect(imported_exercise[:free_form_editor_source]).to_not be_nil}
+        it { expect(subject).to_not be nil }
+        it { expect(subject[:free_form_editor_source]).to_not be_nil}
       end
     end
 


### PR DESCRIPTION
The language field was ill formed in exercises that were imported from Github. 