### PR TITLE
Generic reading of meta and files of guide

### DIFF
--- a/lib/mumukit/sync/store/github/exercise_builder.rb
+++ b/lib/mumukit/sync/store/github/exercise_builder.rb
@@ -9,11 +9,11 @@ class Mumukit::Sync::Store::Github
     end
 
     def build_simple_fields
-      Mumukit::Sync::Store::Github::Schema::Exercise.simple_fields.map { |field| [field.reverse_name, self.send(field.reverse_name)] }.to_h
+      Mumukit::Sync::Store::Github::Schema.build_fields_h(Mumukit::Sync::Store::Github::Schema::Exercise.simple_fields) { |field| self.send(field.reverse_name) }
     end
 
     def build_metadata
-      Mumukit::Sync::Store::Github::Schema::Exercise.metadata_fields.map { |field| [field.reverse_name, meta[field.name.to_s]] }.to_h
+      Mumukit::Sync::Store::Github::Schema.build_fields_h(Mumukit::Sync::Store::Github::Schema::Exercise.metadata_fields) { |field| meta[field.name.to_s] }
     end
   end
 end

--- a/lib/mumukit/sync/store/github/guide_builder.rb
+++ b/lib/mumukit/sync/store/github/guide_builder.rb
@@ -19,27 +19,24 @@ class Mumukit::Sync::Store::Github
       self.exercises << exercise
     end
 
+    def locale
+      meta['locale']
+    end
+
+    def language
+      meta['language']
+    end
+
     private
 
     def build_json
-      raise Mumukit::Sync::SyncError, "Missing guide language" if language[:name].blank?
-
-      {name: name,
-       description: description,
-       corollary: corollary,
-       language: language,
-       locale: locale,
-       type: type,
-       extra: extra,
-       beta: beta,
-       authors: authors,
-       collaborators: collaborators,
-       teacher_info: teacher_info,
-       id_format: id_format,
-       slug: slug,
-       expectations: expectations.to_a,
-       exercises: exercises.sort_by { |e| order.position_for(e[:id]) }}
+      raise Mumukit::Sync::SyncError, "Missing guide language" if language.blank?
+      file = Mumukit::Sync::Store::Github::Schema.build_fields_h(Mumukit::Sync::Store::Github::Schema::Guide.file_fields) { |field| self[field.reverse_name] }
+      metadata = Mumukit::Sync::Store::Github::Schema.build_fields_h(Mumukit::Sync::Store::Github::Schema::Guide.metadata_fields) { |field| self.meta[field.name.to_s] }
+      file.merge(metadata).merge(
+        expectations: expectations.to_a,
+        slug: slug,
+        exercises: exercises.sort_by { |e| order.position_for(e[:id]) }).compact
     end
-
   end
 end

--- a/lib/mumukit/sync/store/github/guide_reader.rb
+++ b/lib/mumukit/sync/store/github/guide_reader.rb
@@ -33,24 +33,18 @@ class Mumukit::Sync::Store::Github
 
     def read_guide_meta!(builder)
       meta = read_meta! 'guide', dir
+      meta['language'] &&= { name: meta['language'] }
+      read_legacy! meta
 
-      builder.language = { name: meta['language'] }
-      builder.locale = meta['locale']
+      builder.meta = meta
 
-      read! 'name', builder, meta
-      read! 'id_format', builder, meta
-      read! 'type', builder, meta
-      read! 'beta', builder, meta
-      read! 'teacher_info', builder, meta
-
-      read_legacy! builder, meta
 
       builder.order = Mumukit::Sync::Store::Github::Ordering.from meta['order']
     end
 
-    def read_legacy!(builder, meta)
-      builder.id_format ||= meta['original_id_format']
-      builder.type ||= meta['learning'] ? 'learning' : 'practice'
+    def read_legacy!(meta)
+      meta['id_format'] ||= meta['original_id_format']
+      meta['type'] ||= meta['learning'] ? 'learning' : 'practice'
     end
 
     def read!(key, builder, meta)

--- a/lib/mumukit/sync/store/github/schema.rb
+++ b/lib/mumukit/sync/store/github/schema.rb
@@ -66,6 +66,10 @@ class Mumukit::Sync::Store::Github
       struct to: block, from: proc { |it| File.read(it) }
     end
 
+    def self.build_fields_h(fields)
+      fields.map { |field| [field.reverse_name, yield(field)] }.to_h
+    end
+
     private
 
     def new_field(it)

--- a/spec/data/simple-guide/meta.yml
+++ b/spec/data/simple-guide/meta.yml
@@ -1,3 +1,4 @@
 language: haskell
 locale: en
 teacher_info: information
+private: true

--- a/spec/data/simple-guide/sources.md
+++ b/spec/data/simple-guide/sources.md
@@ -1,0 +1,1 @@
+this guide comes from here

--- a/spec/mumukit/guide_reader_spec.rb
+++ b/spec/mumukit/guide_reader_spec.rb
@@ -39,6 +39,8 @@ describe Mumukit::Sync::Store::Github::GuideReader do
       let(:guide) { reader.read_guide! }
 
       it { expect(guide[:slug]).to eq 'mumuki/functional-haskell-guide-1'}
+      it { expect(guide[:private]).to be true }
+      it { expect(guide[:sources]).to eq "this guide comes from here\n" }
       it { expect(guide[:exercises].count).to eq 7 }
       it { expect(guide[:description]).to eq "Awesome guide\n" }
       it { expect(guide[:language][:name]).to eq 'haskell' }


### PR DESCRIPTION
I was refactoring this code and I found that some fields - `sources`, `learn_more` and `private` - were not being read. 

The problem was that reading of file and metadata fields was hardcoded, ignoring the schema. 