### PR TITLE
Using name in writable_url

### DIFF
--- a/lib/mumukit/sync/store/github/bot.rb
+++ b/lib/mumukit/sync/store/github/bot.rb
@@ -64,7 +64,7 @@ class Mumukit::Sync::Store::Github
     end
 
     def writable_github_url_for(slug)
-      "https://#{token}:@github.com/#{slug}"
+      "https://#{name}:#{token}@github.com/#{slug}"
     end
 
     def octokit


### PR DESCRIPTION
We had a bug where a Git::Lib.ls_remote was suddenly failing.

Debugging a little I found out that using the url the way we did (https://TOKEN **:**@github.com/SLUG -> note the trailing colon after the token), caused the response array to contain an element like "warning: redirecting to https://TOKEN@github.com/SLUG" which broke everything.
Apparently the right way is user/application:token.